### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/Cake.Putty/Cake.Putty.csproj
+++ b/src/Cake.Putty/Cake.Putty.csproj
@@ -31,8 +31,8 @@
     <DocumentationFile>bin\Release\Cake.Putty.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -68,11 +68,11 @@
     <Compile Include="SshVersion.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Plink\plink-arguments.txt" />
     <Content Include="Pscp\pscp-arguments.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Cake.Putty/Plink/GenericPlinkRunner.cs
+++ b/src/Cake.Putty/Plink/GenericPlinkRunner.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.Tooling;
 
 namespace Cake.Putty
 {
@@ -18,9 +19,9 @@ namespace Cake.Putty
         /// <param name="fileSystem"></param>
         /// <param name="environment"></param>
         /// <param name="processRunner"></param>
-        /// <param name="globber"></param>
-        public GenericPlinkRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) 
-            : base(fileSystem, environment, processRunner, globber)
+        /// <param name="tools"></param>
+        public GenericPlinkRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools) 
+            : base(fileSystem, environment, processRunner, tools)
         {
         }
 

--- a/src/Cake.Putty/Plink/PlinkResolver.cs
+++ b/src/Cake.Putty/Plink/PlinkResolver.cs
@@ -25,7 +25,7 @@ namespace Cake.Putty
 
             // Cake already searches the PATH for the executable tool names.
             // Check for other known locations.
-            return !environment.IsUnix() 
+            return !environment.Platform.IsUnix() 
                 ? CheckCommonWindowsPaths(fileSystem)
                 : null;
         }

--- a/src/Cake.Putty/Plink/PlinkTool.cs
+++ b/src/Cake.Putty/Plink/PlinkTool.cs
@@ -22,13 +22,13 @@ namespace Cake.Putty
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
-        /// <param name="globber">The globber.</param>
+        /// <param name="tools">The tools locator.</param>
         protected PlinkTool(
             IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
-            IGlobber globber)
-            : base(fileSystem, environment, processRunner, globber)
+            IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
         {
             _fileSystem = fileSystem;
             _environment = environment;

--- a/src/Cake.Putty/Plink/PuttyAliases.Plink.cs
+++ b/src/Cake.Putty/Plink/PuttyAliases.Plink.cs
@@ -44,7 +44,7 @@ namespace Cake.Putty
             {
                 throw new ArgumentNullException(nameof(command));
             }
-            var runner = new GenericPlinkRunner<PlinkSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            var runner = new GenericPlinkRunner<PlinkSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(host, command, settings ?? new PlinkSettings());
         }
     }

--- a/src/Cake.Putty/Pscp/GenericPscpRunner.cs
+++ b/src/Cake.Putty/Pscp/GenericPscpRunner.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.Tooling;
 
 namespace Cake.Putty
 {
@@ -18,9 +19,9 @@ namespace Cake.Putty
         /// <param name="fileSystem"></param>
         /// <param name="environment"></param>
         /// <param name="processRunner"></param>
-        /// <param name="globber"></param>
-        public GenericPscpRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) 
-            : base(fileSystem, environment, processRunner, globber)
+        /// <param name="tools"></param>
+        public GenericPscpRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools) 
+            : base(fileSystem, environment, processRunner, tools)
         {
         }
 

--- a/src/Cake.Putty/Pscp/PscpResolver.cs
+++ b/src/Cake.Putty/Pscp/PscpResolver.cs
@@ -25,7 +25,7 @@ namespace Cake.Putty
 
             // Cake already searches the PATH for the executable tool names.
             // Check for other known locations.
-            return !environment.IsUnix() 
+            return !environment.Platform.IsUnix() 
                 ? CheckCommonWindowsPaths(fileSystem)
                 : null;
         }

--- a/src/Cake.Putty/Pscp/PscpTool.cs
+++ b/src/Cake.Putty/Pscp/PscpTool.cs
@@ -22,13 +22,13 @@ namespace Cake.Putty
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
-        /// <param name="globber">The globber.</param>
+        /// <param name="tools">The tool locator.</param>
         protected PscpTool(
             IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
-            IGlobber globber)
-            : base(fileSystem, environment, processRunner, globber)
+            IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
         {
             _fileSystem = fileSystem;
             _environment = environment;

--- a/src/Cake.Putty/Pscp/PuttyAliases.Pscp.cs
+++ b/src/Cake.Putty/Pscp/PuttyAliases.Pscp.cs
@@ -67,7 +67,7 @@ namespace Cake.Putty
             {
                 throw new ArgumentNullException("to");
             }
-            var runner = new GenericPscpRunner<PscpSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            var runner = new GenericPscpRunner<PscpSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             List<string> additional = new List<string>(from);
             additional.Add(to);
             runner.Run(settings ?? new PscpSettings(), additional);

--- a/src/Cake.Putty/packages.config
+++ b/src/Cake.Putty/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.10.1" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
 </packages>

--- a/src/Cake.PuttyTests/Cake.PuttyTests.csproj
+++ b/src/Cake.PuttyTests/Cake.PuttyTests.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>

--- a/src/Cake.PuttyTests/packages.config
+++ b/src/Cake.PuttyTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.10.1" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.

There was a failing unit test too...made it pass but unsure if it's correct so please review. 😉 