### PR TITLE
Do not try to append arguments from inherited class (ToolSettings)

### DIFF
--- a/src/Cake.Putty/ArgumentsBuilderExtension.cs
+++ b/src/Cake.Putty/ArgumentsBuilderExtension.cs
@@ -35,7 +35,7 @@ namespace Cake.Putty
             {
                 settings = new TSettings();
             }
-            foreach (var property in typeof(TSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var property in typeof(TSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
                 foreach (string argument in GetArgumentFromProperty(property, settings))
                 {


### PR DESCRIPTION
Hi Miha,
thanks for Cake.Putty :)
I need to use Plink with following settings:
` PlinkSettings { ToolPath = customFilePath, ...}`

And `ArgumentsBuilderExtension` is throwing exception that the `ToolPath` property is not decorated with attribute. So I propose to exclude all inherited properties from being an argument of plink executable.

Please let me know if you will have any concerns.
